### PR TITLE
fix: @p doesn't need @pattern to be imported

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Patterns"
 uuid = "2ab4f8df-f17a-47f3-bf94-541b2ac2cddd"
 authors = ["Cursor Insight <info@cursorinsight.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -60,6 +60,21 @@ julia> @pattern f(:one) + f(:one) == f(:double, 1)
 ```
 """
 macro pattern(expr)
+    return _pattern(expr)
+end
+
+"""
+Abbreviation for `@pattern`.
+"""
+macro p(expr)
+    return _pattern(expr)
+end
+
+###-----------------------------------------------------------------------------
+### Internals
+###-----------------------------------------------------------------------------
+
+function _pattern(expr)::Expr
     if is_definition(expr) # Pattern in function definition
         def::Dict{Symbol, Any} = splitdef(expr)
 
@@ -74,17 +89,6 @@ macro pattern(expr)
         return esc(expr)
     end
 end
-
-"""
-Abbreviation for `@pattern`.
-"""
-macro p(expr...)
-    return :(@pattern $(expr...)) |> esc
-end
-
-###-----------------------------------------------------------------------------
-### Internals
-###-----------------------------------------------------------------------------
 
 is_definition(expr::Expr)::Bool = isshortdef(expr) || expr.head == :function
 is_definition(_)::Bool = false


### PR DESCRIPTION
Instead of falling back on another macro call, make `@p` and `@pattern` both invoke the same implementation function.